### PR TITLE
Fix Dockerfile: include static files and favicons; invert favicon colors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py index.html favicon.svg ./
-
-ENV DB_PATH=/data/tt.db
+COPY app.py index.html favicon.svg favicon-local.svg ./
+COPY static/ ./static/
 
 EXPOSE 8080
 

--- a/favicon-local.svg
+++ b/favicon-local.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" fill="#f45d48"/>
+  <rect width="32" height="32" fill="#078080"/>
   <text x="16" y="16" font-family="monospace" font-weight="700" font-size="22" fill="#f8f5f2" text-anchor="middle" dominant-baseline="middle" transform="rotate(-45, 16, 16)">tk</text>
 </svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" fill="#078080"/>
+  <rect width="32" height="32" fill="#f45d48"/>
   <text x="16" y="16" font-family="monospace" font-weight="700" font-size="22" fill="#f8f5f2" text-anchor="middle" dominant-baseline="middle" transform="rotate(-45, 16, 16)">tk</text>
 </svg>


### PR DESCRIPTION
## Summary

- **Hotfix**: Dockerfile was not updated when CSS/JS were split into `static/`. Production was serving a blank page because `/static/style.css` and `/static/app.js` returned 404.
- Added `COPY static/ ./static/` and `favicon-local.svg` to the Dockerfile.
- Removed stale `ENV DB_PATH=/data/tt.db` (app uses Postgres, not SQLite).
- Inverted favicon colors: orange (`#f45d48`) for production, teal (`#078080`) for localhost.

## Test plan

- [ ] `https://tikkit.fly.dev` renders correctly
- [ ] Production favicon is orange
- [ ] Localhost favicon is teal