### PR TITLE
Add inline session time editing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -357,6 +357,27 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/* ── Editable session row ── */
+.sl-entry.editable .sl-range {
+  cursor: pointer;
+  transition: color 0.1s;
+}
+.sl-entry.editable:hover .sl-range { color: var(--text); }
+
+/* Inline time inputs */
+.sl-time-input {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--accent);
+  color: var(--accent);
+  font-family: var(--font);
+  font-size: 13px;
+  width: 90px;
+  padding: 0;
+  outline: none;
+}
+.sl-dash { color: var(--dim); }
+
 /* ── Total ── */
 .total-row {
   display: flex;


### PR DESCRIPTION
## Summary
- Click any completed session's time range to edit start/end times inline
- Enter or clicking outside saves; Escape reverts; invalid ranges (end ≤ start) are discarded
- Fixes a double-save race condition that could deadlock the DB via concurrent upserts

## Test plan
- [ ] Start a task, stop it, expand session log, click the time range → two time inputs appear
- [ ] Edit a time, press Enter → duration updates, row returns to text
- [ ] Press Escape → values revert
- [ ] Set end before start → values revert (invalid input rejected)
- [ ] Click outside the inputs → saves
- [ ] Reload page → edited times persist
- [ ] Live (running) sessions are not editable