### PR TITLE
Add delete button for individual session entries

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -178,6 +178,14 @@ function deleteTask(id) {
   render();
 }
 
+function deleteSession(taskId, sessionStart) {
+  const task = data.tasks.find(t => t.id === taskId);
+  if (!task) return;
+  task.sessions = task.sessions.filter(s => s.start !== sessionStart);
+  persist();
+  render();
+}
+
 // ── Tick ──────────────────────────────────────────────────────────────────────
 let ticker = null;
 
@@ -279,6 +287,7 @@ function render() {
               data-task-id="${task.id}" data-session-start="${s.start}">
             <span class="sl-range">${fmtClock(s.start)} – ${live ? 'now' : fmtClock(s.end)}</span>
             <span class="sl-dur"${live ? ` data-live-range="${s.start}"` : ''}>${fmt(dur)}</span>
+            ${live ? '' : `<button class="sl-del" tabindex="-1">✕</button>`}
           </div>`;
         }).join('')}
       </div>` : '';
@@ -414,6 +423,13 @@ listEl.addEventListener('click', e => {
     if (!entry.querySelector('.sl-time-input')) {
       beginEditSession(entry, entry.dataset.taskId, parseInt(entry.dataset.sessionStart));
     }
+    return;
+  }
+
+  const slDel = e.target.closest('.sl-del');
+  if (slDel) {
+    const entry = slDel.closest('.sl-entry');
+    deleteSession(entry.dataset.taskId, parseInt(entry.dataset.sessionStart));
     return;
   }
 

--- a/static/style.css
+++ b/static/style.css
@@ -364,6 +364,22 @@ body {
 }
 .sl-entry.editable:hover .sl-range { color: var(--text); }
 
+.sl-del {
+  opacity: 0;
+  background: none;
+  border: none;
+  color: var(--red);
+  font-family: var(--font);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0 2px;
+  flex-shrink: 0;
+  transition: opacity 0.1s;
+  line-height: 1;
+}
+.sl-entry:hover .sl-del { opacity: 1; }
+.sl-del:hover { filter: brightness(1.3); }
+
 /* Inline time inputs */
 .sl-time-input {
   background: transparent;


### PR DESCRIPTION
## Summary

- Adds a ✕ button to each completed session entry in the expanded task log
- Button is hidden by default, appears on row hover — consistent with the task-level delete UX
- Clicking it removes only that session without affecting the task or other entries
- Live (currently recording) sessions are not deletable

## Test plan

- [ ] Expand a task with multiple sessions, hover a row — ✕ should appear
- [ ] Click ✕ on a session — entry is removed, task total updates correctly
- [ ] Confirm the live (blinking) session has no ✕ button
- [ ] Confirm deleting all sessions from a task leaves the task intact with 0:00:00