### PR TITLE
Make history tasks clickable to start timer

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -321,6 +321,16 @@ historyEl.addEventListener('click', e => {
     return;
   }
 
+  const taskRow = e.target.closest('.day-task-row');
+  if (taskRow) {
+    const task = data.tasks.find(t => t.id === taskRow.dataset.taskId);
+    if (task) {
+      startTask(task);
+      searchEl.focus();
+    }
+    return;
+  }
+
   const row = e.target.closest('.day-row');
   if (!row) return;
   const date = row.dataset.date;

--- a/static/style.css
+++ b/static/style.css
@@ -476,7 +476,10 @@ body {
   padding: 3px 20px 3px 0;
   font-size: 13px;
   color: var(--dimmer);
+  cursor: pointer;
 }
+.day-task-row:hover .dt-name,
+.day-task-row:hover .dt-time { color: var(--dim); }
 
 .dt-name {
   flex: 1;


### PR DESCRIPTION
## Summary
- Clicking a task row in the past-days history section now starts the timer for that task
- Adds `cursor: pointer` and a subtle hover colour lift (`--dimmer` → `--dim`) to signal interactivity

## Test plan
- [ ] Expand a past day in the history section
- [ ] Click a task row — timer should start and header indicator should appear
- [ ] Verify the delete (✕) button on that row still only deletes, not starts the timer
- [ ] Confirm hover colour darkens on `.dt-name` and `.dt-time`