### PR TITLE
Align chevrons and times consistently across all rows

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -313,9 +313,9 @@ function renderHistory() {
 
     return `
       <div class="day-row" data-date="${dateStr}">
-        <span class="day-chevron">${isExp ? '▲' : '▶'}</span>
         <span class="day-label"><span class="day-name">${name}</span> <span class="day-date">${date}</span></span>
         <span class="day-total">${fmt(total)}</span>
+        <span class="day-chevron">${isExp ? '▲' : '▼'}</span>
       </div>
       ${isExp ? `<div class="day-tasks">${
         tasks.map(t => `

--- a/static/style.css
+++ b/static/style.css
@@ -342,11 +342,12 @@ body {
 }
 
 .sl-entry {
+  position: relative;
   display: flex;
   gap: 16px;
   font-size: 13px;
   color: var(--dim);
-  padding: 3px 0;
+  padding: 3px 60px 3px 0;
 }
 
 .sl-entry.live { color: var(--accent); }
@@ -365,6 +366,10 @@ body {
 .sl-entry.editable:hover .sl-range { color: var(--text); }
 
 .sl-del {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
   opacity: 0;
   background: none;
   border: none;
@@ -373,7 +378,6 @@ body {
   font-size: 11px;
   cursor: pointer;
   padding: 0 2px;
-  flex-shrink: 0;
   transition: opacity 0.1s;
   line-height: 1;
 }
@@ -400,7 +404,7 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-top: 2px;
-  padding-top: 14px;
+  padding: 14px 60px 0 0;
 }
 
 .total-label {
@@ -425,7 +429,7 @@ body {
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 8px 20px 8px 0;
+  padding: 8px 30px 8px 22px;
   border-top: 1px solid var(--border);
   cursor: pointer;
   user-select: none;
@@ -461,6 +465,8 @@ body {
   font-size: 13px;
   color: var(--dimmer);
   font-variant-numeric: tabular-nums;
+  min-width: 84px;
+  text-align: right;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- Move history day chevrons from left to right, matching today's task rows; swap ▶ for ▼ to use the same expand/collapse glyphs throughout
- Right-pad `.day-row` to align the day label with task names and the chevron with today's expand arrows
- Give `.day-total` the same `min-width`/`text-align` as `.t-time` so history totals land in the same column
- Fix live session time (blue `.sl-dur`) sitting flush-right by adding right padding to `.sl-entry` and making `.sl-del` absolutely positioned
- Fix today total time sitting flush-right by adding matching right padding to `.total-row`

## Test plan
- [ ] Expand a past day — chevron should be on the right, time and chevron should visually align with today's task rows
- [ ] Start a task and expand its session log — the blue live time should align with the task times above, not sit at the far right
- [ ] Confirm the "today" total time aligns with the task time column
- [ ] Hover an editable session entry — ✕ delete button should still appear at the far right