### PR TITLE
Improve contrast and visual rhythm in the UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3,10 +3,10 @@
 :root {
   --bg:       #f8f5f2;
   --surface:  #fffffe;
-  --border:   #e0dbd6;
+  --border:   #ccc7c2;
   --text:     #232323;
   --dim:      #6e6e6e;
-  --dimmer:   #b0aaa4;
+  --dimmer:   #9c9690;
   --font:     'IBM Plex Mono', monospace;
   --accent:   #0a9e9e;
   --green:    #0a9e9e;
@@ -235,6 +235,8 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+.task-row:last-child { border-bottom-width: 2px; }
+
 .task-row.selected { background: var(--sel); }
 
 .task-row.selected::before {
@@ -404,7 +406,7 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-top: 2px;
-  padding: 14px 60px 0 0;
+  padding: 14px 60px 0 22px;
 }
 
 .total-label {


### PR DESCRIPTION
## Summary
- Darken `--border` (`#e0dbd6` → `#ccc7c2`) and `--dimmer` (`#b0aaa4` → `#9c9690`) for better legibility throughout
- Double the bottom border of the last task row (1px → 2px) to visually close the list
- Align the "today" total label with the task name column (`padding-left: 22px`)

## Test plan
- [ ] Check that borders and muted text are visibly darker but still subtle
- [ ] Confirm the last task row has a slightly thicker bottom border
- [ ] Confirm "today" label aligns with task names above and day labels below