### PR TITLE
Fix Google auth: add requests extra to google-auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ python-jose[cryptography]==3.3.0
 bcrypt==4.2.1
 psycopg2-binary==2.9.10
 httpx==0.28.1
-google-auth==2.38.0
+google-auth[requests]==2.38.0


### PR DESCRIPTION
## Summary
- `google.auth.transport.requests` requires the `requests` library at runtime
- `google-auth` doesn't install it by default; the `[requests]` extra does
- Fixes 500 on `POST /auth/google` in production

## Test plan
- [ ] Sign in with Google on production — no more 500