### PR TITLE
Add minimal Pomodoro timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,8 @@
     <span class="hd-sep">/</span>
     <span class="hd-date" id="hd-date"></span>
     <span class="hd-running" id="hd-running">● recording</span>
+    <button class="hd-pomodoro" id="hd-pomodoro" title="Toggle pomodoro">🍅</button>
+    <input class="hd-pomodoro-mins" id="hd-pomodoro-mins" type="number" min="1" max="60" value="25" title="Pomodoro minutes">
     <button class="hd-logout" id="hd-logout">logout</button>
   </div>
 

--- a/static/style.css
+++ b/static/style.css
@@ -146,6 +146,56 @@ body {
 
 .hd-running.visible { opacity: 1; }
 
+.hd-pomodoro {
+  background: none;
+  border: none;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0.35;
+  transition: opacity 0.15s;
+  line-height: 1;
+}
+
+.hd-pomodoro.active { opacity: 1; }
+.hd-pomodoro:hover { opacity: 0.7; }
+.hd-pomodoro.active:hover { opacity: 0.85; }
+
+@keyframes pomodoro-ring {
+  0%, 100% { transform: scale(1); }
+  20%       { transform: scale(1.4); }
+  40%       { transform: scale(0.9); }
+  60%       { transform: scale(1.3); }
+  80%       { transform: scale(0.95); }
+}
+
+.hd-pomodoro.ringing { animation: pomodoro-ring 0.6s ease; }
+
+.hd-pomodoro-mins {
+  width: 30px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--dim);
+  font-family: var(--font);
+  font-size: 12px;
+  text-align: center;
+  padding: 0 0 1px;
+  outline: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+  -moz-appearance: textfield;
+}
+
+.hd-pomodoro-mins::-webkit-inner-spin-button,
+.hd-pomodoro-mins::-webkit-outer-spin-button { -webkit-appearance: none; }
+
+.hd-pomodoro.active ~ .hd-pomodoro-mins {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .hd-logout {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- 🍅 button in the header toggles Pomodoro mode; muted when off, full opacity when on
- Minutes input (1–60, default 25) appears only when active; value persists in localStorage
- Countdown starts from the session's actual start time — activating mid-session accounts for elapsed time; if already over the limit, nothing fires
- On expiry: two-note bell chime (G5→C6) + tomato bounce animation + browser notification
- Timer clears on task stop, Esc, and logout
- AudioContext is warmed up on the button click (user gesture) to avoid browser autoplay restrictions

## Test plan
- [ ] Click 🍅 → goes full opacity, minutes input appears, browser asks for notification permission
- [ ] Set to 1 min, start a task → chime plays and tomato bounces after 1 minute
- [ ] Start a task, then activate pomodoro mid-session → timer fires after remaining time, not full duration
- [ ] Stop task manually → no chime fires
- [ ] Press Esc to stop → no chime fires
- [ ] Minutes value persists across page reloads