### PR TITLE
Fix clicking a task while search is focused

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -782,6 +782,9 @@ function beginEditSession(entry, taskId, sessionStart) {
 }
 
 // ── Click ─────────────────────────────────────────────────────────────────────
+// Prevent mousedown from blurring the search input — click still fires normally
+listEl.addEventListener('mousedown', e => { e.preventDefault(); });
+
 listEl.addEventListener('click', e => {
   const slRange = e.target.closest('.sl-range');
   if (slRange && slRange.closest('.sl-entry.editable')) {
@@ -817,7 +820,7 @@ listEl.addEventListener('click', e => {
   if (main) {
     const row  = main.closest('.task-row');
     const task = data.tasks.find(t => t.id === row?.dataset.id);
-    if (task) startTask(task);
+    if (task) { startTask(task); searchEl.blur(); }
   }
 });
 


### PR DESCRIPTION
## Summary
- Clicking a task row while typing in the search input triggered blur before click, causing the list to re-render and the click to miss
- Fixed by preventing mousedown on the task list from stealing focus (blur never fires, click lands correctly)
- After a successful click-start, search input is explicitly blurred and cleared — same behaviour as keyboard Enter

## Test plan
- [ ] Type a partial task name, click a matching task in the list → task starts, input clears
- [ ] Click a task row with search empty → still works as before
- [ ] Keyboard flow (Enter to start) unchanged