### PR TITLE
Add value proposition copy to the login screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
   <div class="auth-logo">Tkdoro</div>
 
   <div id="auth-login-view">
+    <p class="auth-pitch">A minimal time tracker with the easiest Pomodoro.</p>
+    <p class="auth-pitch-sub">Try it. It's free.</p>
     <div class="auth-field">
       <input id="auth-email" type="email" placeholder="email" autocomplete="email" spellcheck="false">
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -41,7 +41,20 @@ body {
   font-size: 13px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  margin-bottom: 40px;
+  margin-bottom: 24px;
+}
+
+.auth-pitch {
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.4;
+  margin-bottom: 6px;
+}
+
+.auth-pitch-sub {
+  font-size: 13px;
+  color: var(--dim);
+  margin-bottom: 30px;
 }
 
 .auth-field {


### PR DESCRIPTION
## Summary
- Adds a two-line pitch above the login form: "A minimal time tracker with the easiest Pomodoro." and "Try it. It's free."
- Both lines at 13px to match the app's minimal typographic style

## Test plan
- [ ] Visit tkdoro.live — pitch lines appear between the logo and the email field
- [ ] Sign-up and login flows still work normally
- [ ] Forgot password and reset views unaffected (pitch is inside `#auth-login-view` only)