### PR TITLE
Add guest mode with task sync on sign-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ fly deploy
 
 The app will be available at `https://tt-<yourname>.fly.dev`. Redeploy after code changes with `fly deploy`.
 
+## Guest mode
+
+New visitors land on the tracker immediately — no sign-up required. Tasks are stored in `localStorage` under the key `tt_guest_tasks` and survive page reloads. A banner at the top of the page reminds guests that their data is local and offers a one-click path to sign up. A "sign in" button also appears in the header.
+
+**How it works**
+
+1. On load, if there is no `tt_token` in `localStorage`, the app loads guest data from `localStorage` and renders it directly — no redirect to an auth screen.
+2. The auth form is a modal overlay (`position: fixed`, `z-index: 200`) that floats above the tracker rather than replacing it. Pressing `Escape` dismisses it.
+3. When a guest signs up with email/password and has existing local tasks, those tasks are POSTed to `/data` immediately after signup (before clearing the guest key). The local data becomes the user's server-side data, so nothing is lost.
+4. Logging out switches back to guest mode: the `tt_token` is removed, local guest tasks reload, and the banner reappears.
+
+**Local testing**
+
+1. Open the app in a private/incognito window (no existing token).
+2. You should see the tracker with the guest banner and "sign in" in the header — no login screen.
+3. Add a task, reload — the task should still be there.
+4. Click "Sign up" in the banner, create an account — the modal should close and your tasks should carry over.
+5. Log out — the tracker should stay visible with the guest banner, showing the same local tasks.
+
 ## Google SSO
 
 The app supports sign-in with Google as an alternative to email/password. Both methods coexist — existing password accounts are unaffected. Accounts are matched by email: if the Google account email already exists in the database, that account is used; otherwise a new one is created with `password_hash = NULL`.

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
 <body>
 
 <div id="auth-screen" style="display:none">
+  <div class="auth-inner">
   <div class="auth-logo">Tkdoro</div>
 
   <div id="auth-login-view">
@@ -77,9 +78,10 @@
     <button class="auth-submit" id="reset-submit">set new password</button>
     <div class="auth-error" id="reset-error"></div>
   </div>
+  </div>
 </div>
 
-<div id="app" style="display:none">
+<div id="app">
 
   <div class="hd">
     <span class="hd-logo">Tkdoro</span>
@@ -88,7 +90,13 @@
     <span class="hd-running" id="hd-running">● recording</span>
     <button class="hd-pomodoro" id="hd-pomodoro" title="Toggle pomodoro">🍅</button>
     <input class="hd-pomodoro-mins" id="hd-pomodoro-mins" type="number" min="1" max="60" value="25" title="Pomodoro minutes">
-    <button class="hd-logout" id="hd-logout">logout</button>
+    <button class="hd-logout" id="hd-signin" style="display:none">sign in</button>
+    <button class="hd-logout" id="hd-logout" style="display:none">logout</button>
+  </div>
+
+  <div id="guest-banner">
+    Tasks are saved locally.
+    <button id="guest-signup-btn">Sign up</button> to keep them forever.
   </div>
 
   <div class="search-row">

--- a/static/style.css
+++ b/static/style.css
@@ -31,8 +31,38 @@ body {
 
 /* ── Auth Screen ── */
 #auth-screen {
-  width: 100%;
+  position: fixed;
+  inset: 0;
+  background: rgba(248, 245, 242, 0.97);
+  display: flex;
+  justify-content: center;
+  padding-top: 80px;
+  z-index: 200;
+}
+
+.auth-inner {
   max-width: 400px;
+  width: 100%;
+}
+
+#guest-banner {
+  display: none;
+  font-size: 12px;
+  color: var(--dim);
+  border: 1px solid var(--border);
+  padding: 8px 14px;
+  margin-bottom: 20px;
+}
+
+#guest-banner button {
+  background: none;
+  border: none;
+  font-family: var(--font);
+  font-size: 12px;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
 }
 
 .auth-logo {


### PR DESCRIPTION
## Summary

- New visitors land on the tracker immediately — no sign-up required, tasks saved in `localStorage`
- Guest banner prompts sign-up; tasks are synced to the server on account creation (email/password and Google)
- Auth form is now a dismissible overlay (`position: fixed`) rather than a full-screen replacement; `Escape` closes it
- Logout returns to guest mode showing any previously stored local tasks

## Test plan

- [ ] Open app in incognito — tracker loads immediately with guest banner, no auth screen
- [ ] Add a task, reload — task persists
- [ ] Click "Sign up" in banner → create email/password account → tasks carry over
- [ ] Repeat with Google sign-up from the banner
- [ ] Click "sign in" in header → authenticate with Google → guest tasks carry over
- [ ] Log out → guest banner reappears with local tasks intact
- [ ] Press Escape while auth modal is open → modal dismisses