### PR TITLE
Guest mode: show tracker on landing, sync tasks on sign-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,11 @@
     <button class="hd-logout" id="hd-logout" style="display:none">logout</button>
   </div>
 
+  <div id="guest-banner" style="display:none">
+    Tasks are saved locally.
+    <button id="guest-signup-btn">Sign up</button> to keep them forever.
+  </div>
+
   <div class="search-row">
     <span class="search-prompt">&gt;</span>
     <input id="search" type="text" placeholder="task name…" autocomplete="off" spellcheck="false">

--- a/static/app.js
+++ b/static/app.js
@@ -138,11 +138,13 @@ function showResetView() {
 }
 
 function showGuestMode() {
+  document.getElementById('guest-banner').style.display = 'block';
   document.getElementById('hd-signin').style.display = '';
   document.getElementById('hd-logout').style.display = 'none';
 }
 
 function showUserMode() {
+  document.getElementById('guest-banner').style.display = 'none';
   document.getElementById('hd-signin').style.display = 'none';
   document.getElementById('hd-logout').style.display = '';
 }
@@ -169,6 +171,10 @@ window.addEventListener('popstate', () => {
 
 document.getElementById('hd-signin').addEventListener('click', () => {
   authMode = 'login'; showLoginView(); showAuth();
+});
+
+document.getElementById('guest-signup-btn').addEventListener('click', () => {
+  authMode = 'signup'; showLoginView(); showAuth();
 });
 
 document.getElementById('auth-toggle').addEventListener('click', () => {

--- a/static/style.css
+++ b/static/style.css
@@ -121,6 +121,26 @@ body {
 
 #google-btn { display: flex; justify-content: center; }
 
+/* ── Guest banner ── */
+#guest-banner {
+  font-size: 12px;
+  color: var(--dim);
+  border: 1px solid var(--border);
+  padding: 8px 14px;
+  margin-bottom: 20px;
+}
+
+#guest-banner button {
+  background: none;
+  border: none;
+  font-family: var(--font);
+  font-size: 12px;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
 /* ── App ── */
 #app {
   width: 100%;


### PR DESCRIPTION
## Summary

- Visitors land on the tracker immediately — no login wall
- Tasks are persisted to `localStorage` while in guest mode
- A banner below the header informs guests their data is local and offers a one-click sign-up path
- On sign-up (email/password or Google), guest tasks are synced to the server before the guest key is cleared
- Logout clears the guest key and returns to an empty tracker with the banner visible again
- Browser back button dismisses the auth overlay without navigating away

## Test plan

- [ ] Open app with no token — tracker and guest banner are visible immediately
- [ ] Add tasks, reload — tasks persist via `localStorage`
- [ ] Click "Sign up" in the banner → create account → tasks carry over to server
- [ ] Log out → banner reappears, task list is empty
- [ ] Click "sign in" in header → auth opens; press Escape or browser back → returns to tracker
- [ ] Sign in with Google from the "sign in" button → guest tasks sync if any exist