### PR TITLE
Add Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,14 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-RD37VS5GR1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-RD37VS5GR1');
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

- Adds the Google Analytics gtag.js snippet (G-RD37VS5GR1) to the `<head>`

## Test plan

- [ ] Load the app and verify no console errors
- [ ] Confirm GA events appear in the Google Analytics real-time dashboard