### PR TITLE
Switch to system UI typography and color scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <!-- SEO -->
   <meta name="description" content="Tkdoro — the fastest keyboard-driven time tracker. Type a task, hit Enter to start, hit Enter again to stop. No menus, no friction.">
   <meta name="robots" content="index, follow">
-  <meta name="theme-color" content="#f45d48">
+  <meta name="theme-color" content="#007AFF">
   <link rel="canonical" href="https://tkdoro.live/">
 
   <!-- Open Graph -->
@@ -33,9 +33,6 @@
       document.querySelector('link[rel="icon"]').href = '/favicon-local.svg';
     }
   </script>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <!-- Google tag (gtag.js) -->

--- a/static/style.css
+++ b/static/style.css
@@ -1,17 +1,17 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg:       #f8f5f2;
-  --surface:  #fffffe;
-  --border:   #ccc7c2;
-  --text:     #232323;
-  --dim:      #6e6e6e;
-  --dimmer:   #9c9690;
-  --font:     'IBM Plex Mono', monospace;
-  --accent:   #0a9e9e;
-  --green:    #0a9e9e;
-  --red:      #f45d48;
-  --sel:      #eeeae6;
+  --bg:       #F2F2F7;
+  --surface:  #FFFFFF;
+  --border:   #D1D1D6;
+  --text:     #1C1C1E;
+  --dim:      #636366;
+  --dimmer:   #8E8E93;
+  --font:     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --accent:   #007AFF;
+  --green:    #34C759;
+  --red:      #FF3B30;
+  --sel:      #EBF3FF;
 }
 
 html, body {
@@ -33,7 +33,9 @@ body {
 #auth-screen {
   position: fixed;
   inset: 0;
-  background: rgba(248, 245, 242, 0.97);
+  background: rgba(242, 242, 247, 0.92);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   display: flex;
   justify-content: center;
   padding-top: 80px;
@@ -215,7 +217,7 @@ body {
 .hd-pomodoro.ringing { animation: pomodoro-ring 0.6s ease; }
 
 .hd-pomodoro-mins {
-  width: 30px;
+  width: 36px;
   background: none;
   border: none;
   border-bottom: 1px solid var(--border);
@@ -298,11 +300,13 @@ body {
 .char-up { position: relative; top: -2px; display: inline-block; }
 
 .search-hint kbd {
-  font-family: var(--font);
-  font-size: 12px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
   color: var(--dim);
+  background: var(--surface);
   border: 1px solid var(--border);
-  padding: 0 4px;
+  border-radius: 3px;
+  padding: 1px 5px;
   line-height: 1.4;
 }
 
@@ -387,7 +391,8 @@ body {
 .task-row.running .t-name { color: var(--text); font-weight: 500; }
 
 .t-time {
-  font-size: 15px;
+  font-size: 14px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
   color: var(--dim);
   font-variant-numeric: tabular-nums;
   min-width: 84px;
@@ -453,6 +458,7 @@ body {
   display: flex;
   gap: 16px;
   font-size: 13px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
   color: var(--dim);
   padding: 3px 60px 3px 0;
 }
@@ -522,6 +528,7 @@ body {
 
 .total-time {
   font-size: 13px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
   color: var(--dim);
   font-variant-numeric: tabular-nums;
 }
@@ -580,6 +587,7 @@ body {
 
 .day-total {
   font-size: 13px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
   color: var(--dimmer);
   font-variant-numeric: tabular-nums;
   min-width: 84px;
@@ -615,6 +623,7 @@ body {
   min-width: 84px;
   text-align: right;
   flex-shrink: 0;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-variant-numeric: tabular-nums;
   margin-right: 42px; /* mirrors gap(14px) + chevron(28px) — aligns with day-total */
 }


### PR DESCRIPTION
## Summary
- Replaces IBM Plex Mono + warm teal palette with the native OS system font stack (`-apple-system`, `BlinkMacSystemFont`, `Segoe UI`, etc.) and standard platform colors
- Interactive blue: `#007AFF`, running green: `#34C759`, destructive red: `#FF3B30`
- Background shifts to macOS/iOS grouped surface (`#F2F2F7`); selection tint becomes a light blue (`#EBF3FF`)
- Time/duration fields keep `ui-monospace` for column alignment
- Auth overlay gets a frosted-glass `backdrop-filter: blur(20px)` — very macOS modal
- Removes Google Fonts entirely (zero extra network request)

## Test plan
- [ ] App loads without flash of unstyled monospace text
- [ ] Task list: running task dot is green, timer is blue, delete button is red
- [ ] Selected task row has a blue left border and light blue background
- [ ] Auth overlay is frosted/blurred, not a solid opaque block
- [ ] Keyboard hint badges (`n`, `↵`, `↑↓`, `tab`, `esc`) look like macOS key caps
- [ ] Time columns stay numerically aligned (monospace face)
- [ ] No console errors; no Google Fonts network request in DevTools