### PR TITLE
Move totals above their lists; polish later section

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,11 +116,11 @@
     <kbd>esc</kbd> clear
   </div>
 
-  <ul id="task-list"></ul>
   <div class="total-row" id="total-row" style="display:none">
     <span class="total-label">today</span>
     <span class="total-time" id="total-time"></span>
   </div>
+  <ul id="task-list"></ul>
 
   <div id="history"></div>
 

--- a/static/app.js
+++ b/static/app.js
@@ -625,7 +625,12 @@ function renderHistory() {
 
   const weekTotal = allWeekMs();
 
-  historyEl.innerHTML = days.map(dateStr => {
+  historyEl.innerHTML = `
+    <div class="total-row week-total-row">
+      <span class="total-label">week</span>
+      <span class="total-time" id="week-total-time">${fmt(weekTotal)}</span>
+    </div>
+  ` + days.map(dateStr => {
     const isExp  = expandedDays.has(dateStr);
     const total  = dayTotalMs(dateStr);
     const d      = new Date(dateStr + 'T12:00:00');
@@ -648,12 +653,7 @@ function renderHistory() {
           </div>`).join('')
       }</div>` : ''}
     `;
-  }).join('') + `
-    <div class="total-row week-total-row">
-      <span class="total-label">week</span>
-      <span class="total-time" id="week-total-time">${fmt(weekTotal)}</span>
-    </div>
-  `;
+  }).join('');
 }
 
 historyEl.addEventListener('click', e => {
@@ -697,10 +697,10 @@ function deleteLaterItem(id) {
 function promoteToTask(id) {
   const item = data.later.find(i => i.id === id);
   if (!item) return;
-  data.tasks.push({ id: crypto.randomUUID(), name: item.text, sessions: [] });
+  const task = { id: crypto.randomUUID(), name: item.text, sessions: [] };
+  data.tasks.push(task);
   data.later = data.later.filter(i => i.id !== id);
-  persist();
-  render();
+  startTask(task); // stops any running task, persists, renders
 }
 
 function renderLater() {
@@ -708,7 +708,7 @@ function renderLater() {
   ul.innerHTML = data.later.map(item => `
     <li class="later-item" data-id="${item.id}">
       <span class="later-text">${esc(item.text)}</span>
-      <button class="later-promote" data-id="${item.id}" title="move to tasks">→</button>
+      <button class="later-promote" data-id="${item.id}" title="start task">▶</button>
       <button class="later-del" data-id="${item.id}">✕</button>
     </li>
   `).join('');

--- a/static/style.css
+++ b/static/style.css
@@ -338,7 +338,6 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
-.task-row:last-child { border-bottom-width: 2px; }
 
 .task-row.selected { background: var(--sel); }
 
@@ -517,6 +516,7 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: 6px 60px 6px 22px;
+  border-bottom: 2px solid var(--border);
 }
 
 .total-label {
@@ -538,9 +538,9 @@ body {
   margin-top: 40px;
 }
 
-.day-row:first-child { border-top: none; }
+.week-total-row { border-bottom: 2px solid var(--border); }
 
-.week-total-row { border-top: 2px solid var(--border); }
+.day-row:first-child { border-top: none; }
 
 .day-row {
   display: flex;
@@ -648,8 +648,6 @@ body {
 /* ── Later list ── */
 #later {
   margin-top: 40px;
-  padding-top: 8px;
-  border-top: 1px solid var(--border);
 }
 
 #later-header {
@@ -657,7 +655,9 @@ body {
   color: var(--dimmer);
   text-transform: uppercase;
   letter-spacing: 0.15em;
+  padding: 0 0 8px 22px;
   margin-bottom: 10px;
+  border-bottom: 2px solid var(--border);
 }
 
 #later-input {
@@ -669,7 +669,7 @@ body {
   color: var(--text);
   font-family: var(--font);
   font-size: 14px;
-  padding: 6px 0 8px;
+  padding: 6px 0 8px 22px;
   caret-color: var(--accent);
   margin-bottom: 4px;
   transition: border-color 0.15s;
@@ -684,7 +684,7 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 0;
+  padding: 6px 0 6px 22px;
   border-bottom: 1px solid var(--border);
   font-size: 14px;
 }


### PR DESCRIPTION
## Summary
- **Today / Week totals** now appear as headers above their respective lists instead of footers below them
- **Later section** alignment: 2px rule moves below the "LATER" label; header, input, and items all share the same 22px left indent as the "today" row
- **Later play button** (▶) now immediately starts the promoted task (stopping any currently running task) rather than just moving it to the list

## Test plan
- [ ] "today" label and time appear above today's tasks
- [ ] "week" label and time appear above the history day rows
- [ ] Later section: 2px rule is under the word "LATER", not above it
- [ ] Later header, input placeholder, and list items are all left-aligned at 22px
- [ ] Clicking ▶ on a later item: task appears in the list and starts immediately (green dot, timer running)
- [ ] If another task was running when ▶ is clicked, it is stopped first