### PR TITLE
Polish pomodoro header controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
     <span class="hd-running" id="hd-running">● recording</span>
     <button class="hd-pomodoro" id="hd-pomodoro" title="Toggle pomodoro">🍅</button>
     <input class="hd-pomodoro-mins" id="hd-pomodoro-mins" type="number" min="1" max="60" value="25" title="Pomodoro minutes">
+    <span class="hd-sep">/</span>
     <button class="hd-logout" id="hd-signin" style="display:none">sign in</button>
     <button class="hd-logout" id="hd-logout" style="display:none">logout</button>
   </div>

--- a/static/style.css
+++ b/static/style.css
@@ -227,7 +227,7 @@ body {
   text-align: center;
   padding: 0 0 1px;
   outline: none;
-  opacity: 0;
+  opacity: 0.25;
   pointer-events: none;
   transition: opacity 0.15s;
   -moz-appearance: textfield;


### PR DESCRIPTION
## Summary
- Minutes input is now always visible at 25% opacity when pomodoro is off (fully opaque when on), so users can see the current value at a glance
- Added a `/` separator between the pomodoro controls and the sign-in/logout button for cleaner visual grouping

## Test plan
- [ ] Minutes input and underline are faintly visible when pomodoro is off
- [ ] Activating pomodoro brings the input to full opacity
- [ ] `/` separator appears between the minutes input and the auth button
- [ ] No layout shifts in the header