### PR TITLE
Match favicon background to interface blue

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" fill="#f45d48"/>
+  <rect width="32" height="32" fill="#007AFF"/>
   <text x="16" y="16" font-family="monospace" font-weight="700" font-size="22" fill="#f8f5f2" text-anchor="middle" dominant-baseline="middle" transform="rotate(-45, 16, 16)">tk</text>
 </svg>


### PR DESCRIPTION
## Summary

- Changes favicon background from red-orange (`#f45d48`) to the interface accent blue (`#007AFF`)

## Test plan

- [ ] Confirm favicon appears blue in browser tab in production