### PR TITLE
Rebrand to Doing It / doingit.online

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,8 +24,8 @@ DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://localhost/tt")
 ALGORITHM = "HS256"
 TOKEN_EXPIRE_DAYS = 30
 RESEND_API_KEY       = os.getenv("RESEND_API_KEY", "")
-RESEND_FROM          = os.getenv("RESEND_FROM", "noreply@tkdoro.live")
-APP_URL              = os.getenv("APP_URL", "https://tkdoro.live")
+RESEND_FROM          = os.getenv("RESEND_FROM", "noreply@doingit.online")
+APP_URL              = os.getenv("APP_URL", "https://doingit.online")
 RESET_EXPIRE_MINUTES = 60
 GOOGLE_CLIENT_ID     = os.getenv("GOOGLE_CLIENT_ID", "")
 

--- a/favicon-local.svg
+++ b/favicon-local.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" fill="#078080"/>
-  <text x="16" y="16" font-family="monospace" font-weight="700" font-size="22" fill="#f8f5f2" text-anchor="middle" dominant-baseline="middle" transform="rotate(-45, 16, 16)">tk</text>
+  <text x="16" y="16" font-family="monospace" font-weight="700" font-size="22" fill="#f8f5f2" text-anchor="middle" dominant-baseline="middle" transform="rotate(-45, 16, 16)">di</text>
 </svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" fill="#007AFF"/>
-  <text x="16" y="16" font-family="monospace" font-weight="700" font-size="22" fill="#f8f5f2" text-anchor="middle" dominant-baseline="middle" transform="rotate(-45, 16, 16)">tk</text>
+  <text x="16" y="16" font-family="monospace" font-weight="700" font-size="22" fill="#f8f5f2" text-anchor="middle" dominant-baseline="middle" transform="rotate(-45, 16, 16)">di</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -3,30 +3,30 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tkdoro</title>
+  <title>Doing It</title>
 
   <!-- SEO -->
-  <meta name="description" content="Tkdoro — the fastest keyboard-driven time tracker. Type a task, hit Enter to start, hit Enter again to stop. No menus, no friction.">
+  <meta name="description" content="Doing It — the fastest keyboard-driven time tracker. Type a task, hit Enter to start, hit Enter again to stop. No menus, no friction.">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#007AFF">
-  <link rel="canonical" href="https://tkdoro.live/">
+  <link rel="canonical" href="https://doingit.online/">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://tkdoro.live/">
-  <meta property="og:site_name" content="Tkdoro">
-  <meta property="og:title" content="Tkdoro — keyboard-driven time tracking">
+  <meta property="og:url" content="https://doingit.online/">
+  <meta property="og:site_name" content="Doing It">
+  <meta property="og:title" content="Doing It — keyboard-driven time tracking">
   <meta property="og:description" content="The fastest time tracker. Type a task, press Enter to start recording. No menus, no friction. See where your day actually went.">
-  <meta property="og:image" content="https://tkdoro.live/static/og.png">
+  <meta property="og:image" content="https://doingit.online/static/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Tkdoro — keyboard-driven time tracking">
+  <meta name="twitter:title" content="Doing It — keyboard-driven time tracking">
   <meta name="twitter:description" content="The fastest time tracker. Type a task, press Enter to start. No menus, no friction.">
-  <meta name="twitter:image" content="https://tkdoro.live/static/og.png">
+  <meta name="twitter:image" content="https://doingit.online/static/og.png">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <script>
     if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
@@ -48,7 +48,7 @@
 
 <div id="auth-screen" style="display:none">
   <div class="auth-inner">
-  <div class="auth-logo">Tkdoro</div>
+  <div class="auth-logo">Doing It</div>
 
   <div id="auth-login-view">
     <p class="auth-pitch">A minimal time tracker with the easiest Pomodoro.</p>
@@ -89,7 +89,7 @@
 <div id="app">
 
   <div class="hd">
-    <span class="hd-logo">Tkdoro</span>
+    <span class="hd-logo">Doing It</span>
     <span class="hd-sep">/</span>
     <span class="hd-date" id="hd-date"></span>
     <span class="hd-running" id="hd-running">● recording</span>
@@ -134,10 +134,10 @@
 </div>
 <footer class="share-footer">
   <span class="share-label">share</span>
-  <a class="share-link" href="https://twitter.com/intent/tweet?text=Tkdoro+%E2%80%94+the+fastest+keyboard-driven+time+tracker&url=https%3A%2F%2Ftkdoro.live" target="_blank" rel="noopener">𝕏</a>
-  <a class="share-link" href="https://news.ycombinator.com/submitlink?u=https%3A%2F%2Ftkdoro.live&t=Tkdoro+%E2%80%93+keyboard-driven+time+tracking" target="_blank" rel="noopener">HN</a>
+  <a class="share-link" href="https://twitter.com/intent/tweet?text=Doing+It+%E2%80%94+the+fastest+keyboard-driven+time+tracker&url=https%3A%2F%2Fdoingit.online" target="_blank" rel="noopener">𝕏</a>
+  <a class="share-link" href="https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fdoingit.online&t=Doing+It+%E2%80%93+keyboard-driven+time+tracking" target="_blank" rel="noopener">HN</a>
   <a class="share-link" href="https://www.producthunt.com/posts/new" target="_blank" rel="noopener">PH</a>
-  <a class="share-link" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Ftkdoro.live" target="_blank" rel="noopener">in</a>
+  <a class="share-link" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fdoingit.online" target="_blank" rel="noopener">in</a>
 </footer>
 <script src="/static/app.js"></script>
 </body>

--- a/static/og.svg
+++ b/static/og.svg
@@ -15,7 +15,7 @@
     fill="#f45d48"
     text-anchor="middle"
     letter-spacing="-2"
-  >Tikkit</text>
+  >Doing It</text>
 
   <!-- Tagline -->
   <text
@@ -47,5 +47,5 @@
     font-size="18"
     fill="#b0aaa4"
     text-anchor="end"
-  >tikkit.fly.dev</text>
+  >doingit.online</text>
 </svg>


### PR DESCRIPTION
## Summary

- Rename app from Tkdoro → **Doing It** throughout the UI (page title, auth screen logo, header, OG tags)
- Update all URLs from `tkdoro.live` → `doingit.online` (canonical, OG, Twitter card, share links)
- Update favicon text from `tk` → `di`
- Update OG image wordmark and URL watermark
- Update default `RESEND_FROM` and `APP_URL` fallbacks in `app.py`

Note: `fly.toml` app name (`tikkit`) is left unchanged — that's an infra identifier, not a brand asset.

## Test plan

- [ ] Page title shows "Doing It" in browser tab
- [ ] Auth screen and header logo show "Doing It"
- [ ] Favicon shows "di"
- [ ] OG/Twitter preview cards reflect new name and domain
- [ ] Share links point to doingit.online
- [ ] Password reset emails send from noreply@doingit.online (after setting env var)