### PR TITLE
Allow mouse clicks to focus session time inputs

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -900,7 +900,9 @@ function beginEditSession(entry, taskId, sessionStart) {
 
 // ── Click ─────────────────────────────────────────────────────────────────────
 // Prevent mousedown from blurring the search input — click still fires normally
-listEl.addEventListener('mousedown', e => { e.preventDefault(); });
+listEl.addEventListener('mousedown', e => {
+  if (!e.target.closest('.sl-time-input')) e.preventDefault();
+});
 
 listEl.addEventListener('click', e => {
   const slRange = e.target.closest('.sl-range');


### PR DESCRIPTION
## Summary

- The list's `mousedown` handler was calling `preventDefault()` on all events to keep the search input focused, which also blocked mouse clicks on the session time inputs
- Now exempts `.sl-time-input` elements so clicking directly on a start/end time field focuses it normally

## Test plan

- [ ] Add a completed session, expand it, click the time range to enter edit mode
- [ ] Click directly on the start or end time input with the mouse — should focus and be editable
- [ ] Clicking elsewhere in the list still doesn't blur the search input