### PR TITLE
Soften page background to warm off-white

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,7 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg:       #F2F2F7;
+  --bg:       #FCFBFB;
   --surface:  #FFFFFF;
   --border:   #D1D1D6;
   --text:     #1C1C1E;


### PR DESCRIPTION
## Summary
- Updates `--bg` CSS variable from `#F2F2F7` (cool iOS grey) to `#FCFBFB` (warm near-white)
- Makes the canvas feel lighter and less clinical

## Test plan
- [ ] Open the app and verify the background looks warm/off-white rather than grey
- [ ] Check on both light and dark system themes