### PR TITLE
Move create-task hint inline and make it clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
   <div class="search-row">
     <span class="search-prompt">&gt;</span>
     <input id="search" type="text" placeholder="task name…" autocomplete="off" spellcheck="false">
+    <span id="search-create-hint"><span class="hint-return">↵</span> new</span>
   </div>
   <div class="search-hint">
     <kbd>n</kbd> new &nbsp;·&nbsp;

--- a/static/app.js
+++ b/static/app.js
@@ -729,14 +729,9 @@ function render() {
 
   listEl.innerHTML = '';
 
-  // create hint
+  // create hint (inline in search row)
   const exactMatch = tasks.find(t => t.name.toLowerCase() === qLC);
-  if (q && !exactMatch) {
-    const li = document.createElement('li');
-    li.className = 'create-hint';
-    li.innerHTML = `↵ &nbsp;create <em>"${esc(q)}"</em>`;
-    listEl.appendChild(li);
-  }
+  document.getElementById('search-create-hint').classList.toggle('visible', !!(q && !exactMatch));
 
   // empty state
   if (!q && tasks.length === 0) {
@@ -798,6 +793,18 @@ function render() {
 }
 
 // ── Keyboard ──────────────────────────────────────────────────────────────────
+document.getElementById('search-create-hint').addEventListener('mousedown', e => {
+  e.preventDefault(); // keep focus on input
+  const q = query();
+  if (!q) return;
+  const task = { id: crypto.randomUUID(), name: q, sessions: [] };
+  data.tasks.unshift(task);
+  startTask(task);
+  searchEl.value = '';
+  selIdx = -1;
+  render();
+});
+
 searchEl.addEventListener('input', () => { selIdx = -1; render(); });
 
 searchEl.addEventListener('blur', () => {

--- a/static/style.css
+++ b/static/style.css
@@ -313,17 +313,21 @@ body {
 /* ── Task list ── */
 #task-list { list-style: none; }
 
-.create-hint {
-  font-size: 15px;
+#search-create-hint {
+  font-size: 13px;
   color: var(--dim);
-  padding: 14px 0;
-  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  flex-shrink: 0;
+  display: none;
+  padding-right: 2px;
+  cursor: pointer;
 }
 
-.create-hint em {
-  font-style: normal;
-  color: var(--accent);
-}
+#search-create-hint:hover { color: var(--accent); }
+
+#search-create-hint.visible { display: block; }
+
+.hint-return { position: relative; top: 2px; display: inline-block; }
 
 .empty-state {
   font-size: 15px;


### PR DESCRIPTION
## Summary
- Replaces the below-the-fold `create-hint` list item with an inline `↵ new` badge at the far right of the search bar
- Clicking the badge creates and starts the task immediately (same as pressing Enter)
- The `↵` character is nudged down 2 px for better optical alignment
- Hover turns accent blue so it reads as interactive

## Test plan
- [ ] Type a new task name — confirm `↵ new` appears at the right of the search bar
- [ ] Click `↵ new` — task is created and recording starts
- [ ] Type an existing task name — confirm the hint disappears
- [ ] Clear the input — confirm the hint disappears