### PR TITLE
Add beaver mascot to replace the search prompt caret

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,29 @@
   </div>
 
   <div class="search-row">
-    <span class="search-prompt">&gt;</span>
+    <span class="search-prompt">
+      <svg width="35" height="42" viewBox="0 0 22 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <!-- Ears -->
+        <circle cx="5"  cy="5.5" r="3.2" fill="#7B4F2E"/>
+        <circle cx="17" cy="5.5" r="3.2" fill="#7B4F2E"/>
+        <circle cx="5"  cy="5.5" r="1.8" fill="#C4845A"/>
+        <circle cx="17" cy="5.5" r="1.8" fill="#C4845A"/>
+        <!-- Head -->
+        <circle cx="11" cy="13" r="8.5" fill="#8B5E3C"/>
+        <!-- Eyes -->
+        <circle cx="7.5"  cy="11.5" r="2.2" fill="#1C1C1E"/>
+        <circle cx="14.5" cy="11.5" r="2.2" fill="#1C1C1E"/>
+        <circle cx="8.2"  cy="10.7" r="0.8" fill="white"/>
+        <circle cx="15.2" cy="10.7" r="0.8" fill="white"/>
+        <!-- Nose -->
+        <ellipse cx="11" cy="15" rx="1.5" ry="1" fill="#4A2810"/>
+        <!-- Smile -->
+        <path d="M 8.5 16.5 Q 11 18.5 13.5 16.5" stroke="#4A2810" stroke-width="1.1" fill="none" stroke-linecap="round"/>
+        <!-- Teeth -->
+        <rect x="7.8"  y="17.5" width="2.6" height="4.5" rx="0.8" fill="#FFFFF0" stroke="#D4C89A" stroke-width="0.4"/>
+        <rect x="11.6" y="17.5" width="2.6" height="4.5" rx="0.8" fill="#FFFFF0" stroke="#D4C89A" stroke-width="0.4"/>
+      </svg>
+    </span>
     <input id="search" type="text" placeholder="task name…" autocomplete="off" spellcheck="false">
     <span id="search-create-hint"><span class="hint-return">↵</span> new</span>
   </div>

--- a/static/style.css
+++ b/static/style.css
@@ -266,12 +266,9 @@ body {
 .search-row:focus-within { border-bottom-color: var(--accent); }
 
 .search-prompt {
-  color: var(--accent);
-  font-weight: 700;
-  font-size: 22px;
   flex-shrink: 0;
-  padding-bottom: 10px;
-  padding-top: 8px;
+  line-height: 0;
+  padding: 6px 2px 6px 0;
   user-select: none;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- Replaces the plain `>` caret next to the task input with a small inline SVG beaver face
- Big eyes with shine, nose, smile, and buck teeth — pure SVG, no dependencies
- Beaver chosen as the mascot for Doing It: the ultimate doer

## Test plan
- [ ] Open the app and verify the beaver appears to the left of the task input
- [ ] Verify the input still works normally (focus, typing, keyboard shortcuts)
- [ ] Check it looks reasonable on mobile widths