### PR TITLE
Fix Dockerfile: swap SVG favicons for favicon-local.png

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py index.html favicon.svg favicon-local.svg ./
+COPY app.py index.html favicon-local.png ./
 COPY static/ ./static/
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- Dockerfile was still copying `favicon.svg` and `favicon-local.svg` which no longer exist
- Replace with `favicon-local.png` (prod favicon comes from `static/` which is already copied)

## Test plan
- [ ] Deploy succeeds
- [ ] Beaver favicon visible on doingit.online