### PR TITLE
Show ♛ vip badge for comped users

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
     <button class="hd-logout" id="hd-logout" style="display:none">logout</button>
     <button class="hd-logout hd-upgrade" id="hd-upgrade" style="display:none">upgrade</button>
     <button class="hd-logout hd-manage" id="hd-manage" style="display:none">pro ✓</button>
+    <span class="hd-vip" id="hd-vip" style="display:none">♛ vip</span>
   </div>
 
   <div id="billing-success-banner" style="display:none">

--- a/static/app.js
+++ b/static/app.js
@@ -197,8 +197,9 @@ async function fetchBillingStatus() {
 function updateBillingUI() {
   const token = localStorage.getItem('tt_token');
   const subscribed = subscriptionStatus === 'active' || isComped;
-  document.getElementById('hd-upgrade').style.display = (token && !subscribed) ? '' : 'none';
-  document.getElementById('hd-manage').style.display  = (token && subscribed)  ? '' : 'none';
+  document.getElementById('hd-upgrade').style.display = (token && !subscribed)           ? '' : 'none';
+  document.getElementById('hd-manage').style.display  = (token && subscribed && !isComped) ? '' : 'none';
+  document.getElementById('hd-vip').style.display     = (token && isComped)               ? '' : 'none';
 }
 
 function showUpgradeModal(message) {

--- a/static/style.css
+++ b/static/style.css
@@ -764,6 +764,13 @@ body {
 /* ── Upgrade header button ── */
 .hd-upgrade { color: var(--accent) !important; }
 .hd-manage  { color: var(--green)  !important; }
+.hd-vip {
+  color: #b8860b;
+  font-family: var(--font);
+  font-size: 13px;
+  cursor: default;
+  user-select: none;
+}
 
 /* ── Billing success banner ── */
 #billing-success-banner {


### PR DESCRIPTION
## Summary
- Comped users see a golden non-clickable \"♛ vip\" label instead of the \"pro ✓\" button
- Paid subscribers still see the clickable \"pro ✓\" managing their billing portal
- VIP badge has no pointer cursor and is non-interactive

## Test plan
- [ ] Comped user sees \"♛ vip\" in gold in the header
- [ ] Comped user cannot click it (no pointer, no action)
- [ ] Paid subscriber still sees \"pro ✓\" and can open billing portal
- [ ] Free user still sees \"upgrade\"