### PR TITLE
Fix HN share link encoding: use %20 instead of +

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
     <div class="footer-share">
       <span class="share-label">share</span>
       <a class="share-link" href="https://twitter.com/intent/tweet?text=Doing+It+%E2%80%94+the+fastest+keyboard-driven+time+tracker&url=https%3A%2F%2Fdoingit.online" target="_blank" rel="noopener">𝕏</a>
-      <a class="share-link" href="https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fdoingit.online&t=Show+HN%3A+Doing+It+%E2%80%93+the+easiest+To+Do+%E2%86%92+Doing+%E2%86%92+Done+tracker" target="_blank" rel="noopener">HN</a>
+      <a class="share-link" href="https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fdoingit.online&t=Show%20HN%3A%20Doing%20It%20%E2%80%93%20the%20easiest%20To%20Do%20%E2%86%92%20Doing%20%E2%86%92%20Done%20tracker" target="_blank" rel="noopener">HN</a>
       <a class="share-link" href="https://www.producthunt.com/posts/new" target="_blank" rel="noopener">PH</a>
       <a class="share-link" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fdoingit.online" target="_blank" rel="noopener">in</a>
     </div>


### PR DESCRIPTION
## Summary
- HN submitlink was rendering spaces as literal `+` characters in the title field
- Replaced `+` with `%20` so the title displays correctly

## Test plan
- [ ] Click HN link and verify title shows as \"Show HN: Doing It – the easiest To Do → Doing → Done tracker\"