### PR TITLE
Refresh all copy to new To Do → Doing → Done proposition

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:url" content="https://doingit.online/">
   <meta property="og:site_name" content="Doing It">
   <meta property="og:title" content="Doing It — from to-do to done, tracked.">
-  <meta property="og:description" content="The fastest time tracker. Type a task, press Enter to start recording. No menus, no friction. See where your day actually went.">
+  <meta property="og:description" content="The easiest To Do → Doing → Done tracker. Type a task, press Enter to start. No menus, no friction.">
   <meta property="og:image" content="https://doingit.online/static/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -25,7 +25,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Doing It — from to-do to done, tracked.">
-  <meta name="twitter:description" content="The fastest time tracker. Type a task, press Enter to start. No menus, no friction.">
+  <meta name="twitter:description" content="The easiest To Do → Doing → Done tracker. Type a task, press Enter to start. No menus, no friction.">
   <meta name="twitter:image" content="https://doingit.online/static/og.png">
   <link rel="icon" type="image/png" href="/static/beaver.png">
   <script>
@@ -51,7 +51,7 @@
   <div class="auth-logo">Doing It</div>
 
   <div id="auth-login-view">
-    <p class="auth-pitch">A minimal time tracker with the easiest Pomodoro.</p>
+    <p class="auth-pitch">The easiest To Do → Doing → Done tracker.</p>
     <p class="auth-pitch-sub">Try it. It's free.</p>
     <div class="auth-field">
       <input id="auth-email" type="email" placeholder="email" autocomplete="email" spellcheck="false">
@@ -146,7 +146,7 @@
     <span class="footer-contact">Questions, suggestions? <a href="mailto:gustavo@poe.ma">Write Gustavo Saiani</a> / <a href="https://www.linkedin.com/in/gusaiani/" target="_blank" rel="noopener">I'm looking for my next job!</a></span>
     <div class="footer-share">
       <span class="share-label">share</span>
-      <a class="share-link" href="https://twitter.com/intent/tweet?text=Doing+It+%E2%80%94+the+fastest+keyboard-driven+time+tracker&url=https%3A%2F%2Fdoingit.online" target="_blank" rel="noopener">𝕏</a>
+      <a class="share-link" href="https://twitter.com/intent/tweet?text=Doing%20It%20%E2%80%94%20the%20easiest%20To%20Do%20%E2%86%92%20Doing%20%E2%86%92%20Done%20tracker&url=https%3A%2F%2Fdoingit.online" target="_blank" rel="noopener">𝕏</a>
       <a class="share-link" href="https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fdoingit.online&t=Show%20HN%3A%20Doing%20It%20%E2%80%93%20the%20easiest%20To%20Do%20%E2%86%92%20Doing%20%E2%86%92%20Done%20tracker" target="_blank" rel="noopener">HN</a>
       <a class="share-link" href="https://www.producthunt.com/posts/new" target="_blank" rel="noopener">PH</a>
       <a class="share-link" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fdoingit.online" target="_blank" rel="noopener">in</a>


### PR DESCRIPTION
## Summary
- OG description, Twitter card, auth pitch, and X share link all updated to \"the easiest To Do → Doing → Done tracker\"
- Consistent messaging across all touchpoints

## Test plan
- [ ] Auth screen shows new pitch line
- [ ] X share link pre-fills with new copy
- [ ] OG/Twitter card previews show updated description when sharing the URL