### PR TITLE
Always show at least 5 recent tasks to seed the day

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -700,7 +700,16 @@ function queryLC() { return query().toLowerCase(); }
 
 function filtered() {
   const q = queryLC();
-  if (!q) return data.tasks.filter(t => taskTodayMs(t) > 0 || t.sessions.some(s => !s.end));
+  if (!q) {
+    const todayTasks = data.tasks.filter(t => taskTodayMs(t) > 0 || t.sessions.some(s => !s.end));
+    if (todayTasks.length >= 5) return todayTasks;
+    const todayIds = new Set(todayTasks.map(t => t.id));
+    const recent = data.tasks
+      .filter(t => !todayIds.has(t.id) && t.sessions.length > 0)
+      .sort((a, b) => Math.max(...b.sessions.map(s => s.start)) - Math.max(...a.sessions.map(s => s.start)))
+      .slice(0, 5 - todayTasks.length);
+    return [...todayTasks, ...recent];
+  }
   return data.tasks.filter(t => t.name.toLowerCase().includes(q));
 }
 


### PR DESCRIPTION
## Summary
- If fewer than 5 tasks have activity today, pad with the most recently used tasks (by latest session timestamp)
- Padded tasks show 0:00:00 for today since they have no sessions yet
- Gives users a quick-start list at the beginning of the day