### PR TITLE
Revert tab title and logo back to 'Doing It'

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Do It</title>
+  <title>Doing It</title>
 
   <!-- SEO -->
   <meta name="description" content="Doing It — from to-do to done, tracked. Tasks, time tracking, Pomodoro, and a full history of your day. No menus, just Enter.">

--- a/static/app.js
+++ b/static/app.js
@@ -656,9 +656,9 @@ function fmtTabTimer(ms) {
 
 function updateTabTitle() {
   const cur = runningTask();
-  if (!cur) { document.title = 'Do It'; return; }
+  if (!cur) { document.title = 'Doing It'; return; }
   const session = cur.sessions.find(s => !s.end);
-  if (!session) { document.title = 'Do It'; return; }
+  if (!session) { document.title = 'Doing It'; return; }
   document.title = `${fmtTabTimer(Date.now() - session.start)} · ${cur.name} · Doing It`;
 }
 


### PR DESCRIPTION
Reverts the Do It / Doing It toggle experiment — title and logo stay 'Doing It' always.