### PR TITLE
Don't capture modifier+number shortcuts

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1110,7 +1110,7 @@ document.addEventListener('keydown', async e => {
     document.activeElement.tagName === 'TEXTAREA' ||
     document.activeElement.isContentEditable
   );
-  if (!onInput) {
+  if (!onInput && !e.metaKey && !e.ctrlKey && !e.altKey) {
     const n = parseInt(e.key);
     if (n >= 1 && n <= 7) {
 const task = filtered()[n - 1];


### PR DESCRIPTION
## Summary
- Cmd+1, Ctrl+1, Alt+1 (and other modifier+number combos) now pass through to the browser instead of being captured as task-start shortcuts
- Bare number keys (1–7) still start the corresponding task as before

## Test plan
- [ ] Press `1`–`7` with no modifier — task starts normally
- [ ] Press Cmd+1 (or Ctrl+1 on Windows/Linux) — browser switches to tab 1
- [ ] Press Alt+1 — browser handles it natively