### PR TITLE
Show session and today timers for running tasks

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -669,6 +669,9 @@ function liveUpdate() {
     const t = data.tasks.find(x => x.id === el.dataset.live);
     if (t) el.textContent = fmt(taskTodayMs(t));
   });
+  document.querySelectorAll('[data-live-session]').forEach(el => {
+    el.textContent = fmt(Date.now() - parseInt(el.dataset.liveSession));
+  });
   document.querySelectorAll('[data-live-range]').forEach(el => {
     const s = JSON.parse(el.dataset.liveRange);
     el.textContent = fmt((Date.now()) - s);
@@ -941,7 +944,13 @@ function render() {
       <div class="task-main">
         <span class="t-name">${esc(task.name)}</span>
         <span class="t-dot"></span>
-        <span class="t-time"${isRunning ? ` data-live="${task.id}"` : ''}>${fmt(taskTodayMs(task))}</span>
+        ${(() => {
+          if (isRunning) {
+            const sessionStart = task.sessions.find(s => !s.end).start;
+            return `<span class="t-time"><span class="t-time-label">session</span> <span data-live-session="${sessionStart}">${fmt(Date.now() - sessionStart)}</span> <span class="t-time-sep">·</span> <span class="t-time-label">today</span> <span data-live="${task.id}">${fmt(taskTodayMs(task))}</span></span>`;
+          }
+          return `<span class="t-time">${fmt(taskTodayMs(task))}</span>`;
+        })()}
         <span class="t-expand">${hasLog ? (isExp ? '▲' : '▼') : ''}</span>
         <button class="t-del" data-id="${task.id}" tabindex="-1">✕</button>
       </div>

--- a/static/style.css
+++ b/static/style.css
@@ -406,7 +406,18 @@ body {
   flex-shrink: 0;
 }
 
-.task-row.running .t-time { color: var(--accent); }
+.task-row.running .t-time { color: var(--dim); }
+
+.t-time-label {
+  font-family: var(--font);
+  font-size: 11px;
+  color: var(--dimmer);
+  font-variant-numeric: normal;
+}
+.t-time-sep {
+  color: var(--dimmer);
+  margin: 0 2px;
+}
 
 .t-expand {
   font-size: 10px;


### PR DESCRIPTION
## Summary
- Running tasks now show both the current session duration and total time today
- Format: `session 0:04:21 · today 1:23:00` with dimmer labels and separator
- Time color changed from accent blue to the standard dim color