### PR TITLE
Add toggle to collapse/expand today's task list

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,10 +120,7 @@
   </div>
   <div class="search-hint" id="search-hint"></div>
 
-  <div class="total-row" id="total-row" style="display:none">
-    <span class="total-label">today</span>
-    <span class="total-time" id="total-time"></span>
-  </div>
+  <div class="total-row" id="total-row" style="display:none"></div>
   <ul id="task-list"></ul>
 
   <div id="history"></div>

--- a/static/app.js
+++ b/static/app.js
@@ -685,13 +685,13 @@ function liveUpdate() {
 
 // ── State ─────────────────────────────────────────────────────────────────────
 let selIdx  = -1;
+let tasksVisible = localStorage.getItem('tt_tasks_visible') !== 'false';
 const expanded     = new Set();
 const expandedDays = new Set();
 
 const searchEl   = document.getElementById('search');
 const listEl     = document.getElementById('task-list');
 const totalRow   = document.getElementById('total-row');
-const totalTime  = document.getElementById('total-time');
 const hdRunning  = document.getElementById('hd-running');
 const hdDate     = document.getElementById('hd-date');
 const historyEl  = document.getElementById('history');
@@ -960,10 +960,28 @@ function render() {
     listEl.appendChild(li);
   });
 
-  // total
+  // total row
   const hasData = data.tasks.some(t => t.sessions.some(s => isToday(s.start)));
   totalRow.style.display = hasData ? 'flex' : 'none';
-  totalTime.textContent  = fmt(allTodayMs());
+  listEl.style.display   = tasksVisible ? '' : 'none';
+  if (hasData) {
+    if (!tasksVisible && running) {
+      const sessionStart = running.sessions.find(s => !s.end).start;
+      totalRow.innerHTML = `
+        <span class="total-label">today &nbsp;·&nbsp; <span class="total-active-name">${esc(running.name)}</span></span>
+        <span class="total-time total-time-running">
+          <span class="t-time-label">session</span> <span data-live-session="${sessionStart}">${fmt(Date.now() - sessionStart)}</span>
+          <span class="t-time-sep">·</span>
+          <span class="t-time-label">today</span> <span id="total-time">${fmt(allTodayMs())}</span>
+        </span>
+        <span class="total-expand">▼</span>`;
+    } else {
+      totalRow.innerHTML = `
+        <span class="total-label">today</span>
+        <span class="total-time" id="total-time">${fmt(allTodayMs())}</span>
+        <span class="total-expand">${tasksVisible ? '▲' : '▼'}</span>`;
+    }
+  }
 
   renderHistory();
   renderLater();
@@ -1183,6 +1201,14 @@ document.addEventListener('keydown', async e => {
 });
 
 document.querySelector('.search-prompt').addEventListener('click', () => searchEl.focus());
+
+totalRow.addEventListener('click', e => {
+  if (e.target.closest('.total-expand')) {
+    tasksVisible = !tasksVisible;
+    localStorage.setItem('tt_tasks_visible', tasksVisible);
+    render();
+  }
+});
 
 // ── Later input ───────────────────────────────────────────────────────────────
 document.getElementById('later-input').addEventListener('keydown', e => {

--- a/static/style.css
+++ b/static/style.css
@@ -446,7 +446,7 @@ body {
   cursor: pointer;
   padding: 2px 4px;
   flex-shrink: 0;
-  margin-right: -28px;
+  margin-right: -33px;
   transition: opacity 0.1s;
   line-height: 1;
 }
@@ -532,17 +532,23 @@ body {
 /* ── Total ── */
 .total-row {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 6px 48px 6px 10px;
+  gap: 14px;
+  padding: 6px 0 6px 10px;
   border-bottom: 2px solid var(--border);
+  cursor: pointer;
+  user-select: none;
 }
 
 .total-label {
+  flex: 1;
   font-size: 12px;
   color: var(--dimmer);
   text-transform: uppercase;
   letter-spacing: 0.15em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .total-time {
@@ -555,6 +561,37 @@ body {
 /* ── History ── */
 #history {
   margin-top: 40px;
+}
+
+.total-expand {
+  font-size: 10px;
+  color: var(--dimmer);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s;
+}
+
+.total-row:hover .total-expand { color: var(--dim); }
+.total-expand:hover { background: var(--sel); color: var(--text) !important; }
+
+.total-active-name {
+  color: var(--text);
+  font-size: 12px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.total-time-running {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 13px;
+  color: var(--dim);
+  font-variant-numeric: tabular-nums;
 }
 
 .week-total-row { border-bottom: 2px solid var(--border); }


### PR DESCRIPTION
## Summary
- Triangle chevron on the today row collapses/expands the task list (persisted to localStorage)
- Collapsed + running task: shows active task name on the left and live session/today timers on the right
- Collapsed + no running task: shows standard today total
- Chevron matches task row expand button in size, style, and hover behavior