### PR TITLE
Show expand triangle for all tasks with sessions

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -925,17 +925,28 @@ function render() {
     li.className = ['task-row', isRunning ? 'running' : '', isSel ? 'selected' : ''].join(' ').trim();
     li.dataset.id = task.id;
 
-    const sessionHTML = isExp && hasLog ? `
+    const shownSess  = hasLog ? todaySess : (() => {
+      const last = [...task.sessions].filter(s => s.end).sort((a,b) => b.start - a.start);
+      if (!last.length) return [];
+      const lastDate = localDateStr(new Date(last[0].start));
+      return task.sessions.filter(s => localDateStr(new Date(s.start)) === lastDate);
+    })();
+    const shownDate  = hasLog ? 'today' : (() => {
+      if (!shownSess.length) return '';
+      const d = new Date(shownSess[0].start);
+      return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }).toLowerCase();
+    })();
+    const sessionHTML = isExp && shownSess.length ? `
       <div class="session-log open">
-        <div class="sl-date">today</div>
-        ${todaySess.map(s => {
+        <div class="sl-date">${shownDate}</div>
+        ${shownSess.map(s => {
           const live = !s.end;
           const dur  = (s.end ?? Date.now()) - s.start;
-          return `<div class="sl-entry${live ? ' live' : ' editable'}"
+          return `<div class="sl-entry${live ? ' live' : (hasLog ? ' editable' : '')}"
               data-task-id="${task.id}" data-session-start="${s.start}">
             <span class="sl-range">${fmtClock(s.start)} – ${live ? 'now' : fmtClock(s.end)}</span>
             <span class="sl-dur"${live ? ` data-live-range="${s.start}"` : ''}>${fmt(dur)}</span>
-            ${live ? '' : `<button class="sl-del" tabindex="-1">✕</button>`}
+            ${live ? '' : hasLog ? `<button class="sl-del" tabindex="-1">✕</button>` : ''}
           </div>`;
         }).join('')}
       </div>` : '';
@@ -951,7 +962,7 @@ function render() {
           }
           return `<span class="t-time">${fmt(taskTodayMs(task))}</span>`;
         })()}
-        <span class="t-expand">${hasLog ? (isExp ? '▲' : '▼') : ''}</span>
+        <span class="t-expand">${task.sessions.length ? (isExp ? '▲' : '▼') : ''}</span>
         <button class="t-del" data-id="${task.id}" tabindex="-1">✕</button>
       </div>
       ${sessionHTML}

--- a/static/style.css
+++ b/static/style.css
@@ -610,7 +610,7 @@ body {
 
 .day-chevron {
   font-size: 9px;
-  color: var(--border);
+  color: var(--dimmer);
   width: 28px;
   height: 28px;
   display: flex;
@@ -622,7 +622,7 @@ body {
   transition: color 0.1s, background 0.1s;
 }
 
-.day-row:hover .day-chevron { color: var(--dimmer); }
+.day-row:hover .day-chevron { color: var(--dim); }
 .day-chevron:hover { background: var(--sel); color: var(--text) !important; }
 
 .day-label { flex: 1; }


### PR DESCRIPTION
## Summary
- The ▼ expand triangle was only shown when a task had sessions today (`hasLog`), so recently-used tasks with no today sessions showed a blank `t-expand` span
- Now any task with sessions gets the triangle; expanding a historical task shows its most recent day's sessions (read-only)
- Also fixes the history day-chevron color (was `--border` ≈ invisible; now `--dimmer`)