### PR TITLE
Prevent duplicate sessions from concurrent startTask calls

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -252,10 +252,11 @@ async function canStartSession() {
   const token = localStorage.getItem('tt_token');
   if (token) {
     try {
-      const r = await fetch('/sessions/start', {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` },
-      });
+      const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 4000));
+      const r = await Promise.race([
+        fetch('/sessions/start', { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } }),
+        timeout,
+      ]);
       if (r.status === 402) {
         const body = await r.json();
         showUpgradeModal(body.detail);
@@ -263,7 +264,7 @@ async function canStartSession() {
       }
       return r.ok;
     } catch {
-      return true; // network error: allow optimistically
+      return true; // network error or timeout: allow optimistically
     }
   } else {
     // Guest: client-side trial + rate limit
@@ -594,7 +595,11 @@ function allWeekMs() {
 }
 
 // ── Actions ───────────────────────────────────────────────────────────────────
+let _startingTask = false;
 async function startTask(task) {
+  if (_startingTask) return;
+  _startingTask = true;
+  try {
   const isRunning = task.sessions.some(s => !s.end);
 
   if (!isRunning) {
@@ -617,6 +622,9 @@ async function startTask(task) {
   persist();
   render();
   ensureTick();
+  } finally {
+    _startingTask = false;
+  }
 }
 
 function deleteTask(id) {


### PR DESCRIPTION
## Summary
- A sleeping server caused `canStartSession()` to hang for several seconds; during that window a second click passed the `isRunning` check and pushed a duplicate session
- Added a `_startingTask` mutex so concurrent calls to `startTask()` are dropped until the first one completes
- Added a 4-second timeout on the `/sessions/start` fetch — falls back to optimistic allow (same as existing network-error behaviour), capping the UI freeze from a cold-start server